### PR TITLE
ci/release: fix version reference

### DIFF
--- a/.github/workflows/release_linux.yml
+++ b/.github/workflows/release_linux.yml
@@ -39,4 +39,4 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        gh release upload ${{ github.ref_name }} appimage/NopeViewer-x86_64.AppImage
+        gh release upload v$(cat VERSION) appimage/NopeViewer-x86_64.AppImage

--- a/.github/workflows/release_macos.yml
+++ b/.github/workflows/release_macos.yml
@@ -49,4 +49,4 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        gh release upload ${{ github.ref_name }} nope-viewer.dmg
+        gh release upload v$(cat VERSION) nope-viewer.dmg

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ for the globale releases (`YYYY.MINOR`), and to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html) for `libnopegl`.
 
 ## [Unreleased]
+### Fixed
+- Linux and macOS release jobs
 
 ## [2023.2] [libnopegl 0.9.0] - 2023-09-01
 ### Added


### PR DESCRIPTION
github.ref_name was working when we were relying on tags events, but now we are relying on a workflow dependency, where it is undefined.