### PR TITLE
utils/qml: set default live controls step to 1/100

### DIFF
--- a/pynopegl-utils/pynopegl_utils/qml/livectls.py
+++ b/pynopegl-utils/pynopegl_utils/qml/livectls.py
@@ -69,6 +69,7 @@ def get_model_data(scene) -> List[Dict[str, Any]]:
             label=label,
             val=ctl["val"],
             node=ctl["node"],
+            step=1 / 100,
         )
 
         if spec.base_type in ("int", "uint"):


### PR DESCRIPTION
Fixes the following qml warning:

pynopegl-utils/pynopegl_utils/qml/viewer.qml:385:37: Unable to assign [undefined] to double