### PR TITLE
release_macos: explicitly use Python 3.11

### DIFF
--- a/.github/workflows/release_macos.yml
+++ b/.github/workflows/release_macos.yml
@@ -25,11 +25,11 @@ jobs:
 
     - name: Install dependencies
       run: |
-        brew install ffmpeg freetype fribidi harfbuzz python3 curl pkg-config nasm create-dmg
+        brew install ffmpeg freetype fribidi harfbuzz python@3.11 curl pkg-config nasm create-dmg
 
     - name: Setup venv
       run: |
-        ./configure.py
+        $(brew --prefix)/opt/python@3.11/libexec/bin/python configure.py
 
     - name: Build
       run: |


### PR DESCRIPTION
PyInstaller (as of 6.3.0) with Python 3.12 on macOS has issues resolving the python modules dependencies.