### PR TITLE
api: add ngl_update()

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1285,7 +1285,7 @@ class _EnvBuilder(venv.EnvBuilder):
         if _SYSTEM == "MinGW":
             return
         pip_install = [context.env_exe, "-m", "pip", "install"]
-        pip_install += ["meson", "ninja"]
+        pip_install += ["meson==1.4.2", "ninja"]
         logging.info("install build dependencies: %s", _cmd_join(*pip_install))
         run(pip_install, check=True)
 

--- a/configure.py
+++ b/configure.py
@@ -244,14 +244,14 @@ _EXTERNAL_DEPS = dict(
         sha256="427201f5d5151670d05c1f5b45bef5dda1f2e7dd971ef54f0feaaa7ffd2ab90c",
     ),
     harfbuzz=dict(
-        version="8.4.0",
+        version="9.0.0",
         url="https://github.com/harfbuzz/harfbuzz/archive/refs/tags/@VERSION@.tar.gz",
-        sha256="9f1ca089813b05944ad1ce8c7e018213026d35dc9bab480a21eb876838396556",
+        sha256="b7e481b109d19aefdba31e9f5888aa0cdfbe7608fed9a43494c060ce1f8a34d2",
     ),
     fribidi=dict(
-        version="1.0.13",
+        version="1.0.15",
         url="https://github.com/fribidi/fribidi/archive/refs/tags/v@VERSION@.tar.gz",
-        sha256="f24e8e381bcf76533ae56bd776196f3a0369ec28e9c0fdb6edd163277e008314",
+        sha256="0db5f0621b6fbfae5960c30da4f132009fd72bf4687f1b04a87a4cfc2a08ea38",
     ),
     moltenvk_iOS=dict(
         version="1.2.8",

--- a/configure.py
+++ b/configure.py
@@ -207,10 +207,10 @@ _EXTERNAL_DEPS = dict(
         sha256="fc5d6c096a6b82f86613060dfef553a09b9e08afcb401fefac4b9ca221265cda",
     ),
     glslang=dict(
-        version="14.2.0",
+        version="14.3.0",
         dst_file="glslang-@VERSION@.tar.gz",
         url="https://github.com/KhronosGroup/glslang/archive/refs/tags/@VERSION@.tar.gz",
-        sha256="14a2edbb509cb3e51a9a53e3f5e435dbf5971604b4b833e63e6076e8c0a997b5",
+        sha256="be6339048e20280938d9cb399fcdd06e04f8654d43e170e8cce5a56c9a754284",
     ),
     glslang_Windows=dict(
         # Use the legacy master-tot Windows build until the main-tot one is

--- a/libnopegl/src/api.c
+++ b/libnopegl/src/api.c
@@ -842,6 +842,11 @@ int ngli_prepare_draw(struct ngl_ctx *s, double t)
     return s->api_impl->prepare_draw(s, t);
 }
 
+int ngl_update(struct ngl_ctx *s, double t)
+{
+    return ngli_prepare_draw(s, t);
+}
+
 int ngl_draw(struct ngl_ctx *s, double t)
 {
     if (!s->configured) {

--- a/libnopegl/src/nopegl.h.in
+++ b/libnopegl/src/nopegl.h.in
@@ -901,6 +901,16 @@ NGL_API int ngl_set_capture_buffer(struct ngl_ctx *s, void *capture_buffer);
 NGL_API int ngl_set_scene(struct ngl_ctx *s, struct ngl_scene *scene);
 
 /**
+ * Update at the specified time.
+ *
+ * @param s     pointer to the configured nope.gl context
+ * @param t     target update time in seconds
+ *
+ * @return 0 on success, NGL_ERROR_* (< 0) on error
+ */
+NGL_API int ngl_update(struct ngl_ctx *s, double t);
+
+/**
  * Draw at the specified time.
  *
  * @param s     pointer to the configured nope.gl context

--- a/pynopegl/_pynopegl.pyx
+++ b/pynopegl/_pynopegl.pyx
@@ -184,6 +184,7 @@ cdef extern from "nopegl.h":
     int ngl_get_viewport(ngl_ctx *s, int32_t *viewport)
     int ngl_set_capture_buffer(ngl_ctx *s, void *capture_buffer)
     int ngl_set_scene(ngl_ctx *s, ngl_scene *scene)
+    int ngl_update(ngl_ctx *s, double t) nogil
     int ngl_draw(ngl_ctx *s, double t) nogil
     char *ngl_dot(ngl_ctx *s, double t) nogil
     int ngl_livectls_get(ngl_scene *scene, size_t *nb_livectlsp, ngl_livectl **livectlsp)
@@ -743,6 +744,11 @@ cdef class Context:
             ptr = scene.cptr
             c_scene = <ngl_scene *>ptr
         return ngl_set_scene(self.ctx, c_scene)
+
+    def update(self, double t):
+        with nogil:
+            ret = ngl_update(self.ctx, t)
+        return ret
 
     def draw(self, double t):
         with nogil:

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -74,6 +74,7 @@ foreach backend : backends
     'get_backend',
     'viewport',
     'transform_chain_check',
+    'update_with_timeranges',
   ]
   if has_text_libraries
     tests_api += 'text_live_change_with_font'


### PR DESCRIPTION
This allows to trigger graph updates without producing frames. This is particularly useful to trigger a prefetch or release on given graph (without producing any frame).

Depends on https://github.com/NopeForge/nope.gl/pull/265.