### PR TITLE
Simplify ngpu program interface (gl)

### DIFF
--- a/libnopegl/src/filterschain.c
+++ b/libnopegl/src/filterschain.c
@@ -25,6 +25,7 @@
 #include "ngpu/pgcraft.h"
 #include "utils/bstr.h"
 #include "utils/darray.h"
+#include "utils/hmap.h"
 #include "utils/memory.h"
 
 /* Shader helpers */

--- a/libnopegl/src/ngpu/opengl/program_gl.c
+++ b/libnopegl/src/ngpu/opengl/program_gl.c
@@ -75,174 +75,6 @@ static int program_check_status(const struct glcontext *gl, GLuint id, GLenum st
     return NGL_ERROR_INVALID_DATA;
 }
 
-static void free_pinfo(void *user_arg, void *data)
-{
-    ngli_free(data);
-}
-
-static struct ngpu_program_variable_info *program_variable_info_create()
-{
-    struct ngpu_program_variable_info *info = ngli_calloc(1, sizeof(*info));
-    if (!info)
-        return NULL;
-    info->binding  = -1;
-    info->location = -1;
-    return info;
-}
-
-static struct hmap *program_probe_uniforms(struct glcontext *gl, GLuint pid)
-{
-    struct hmap *umap = ngli_hmap_create(NGLI_HMAP_TYPE_STR);
-    if (!umap)
-        return NULL;
-    ngli_hmap_set_free_func(umap, free_pinfo, NULL);
-
-    GLint nb_active_uniforms;
-    gl->funcs.GetProgramiv(pid, GL_ACTIVE_UNIFORMS, &nb_active_uniforms);
-    for (GLint i = 0; i < nb_active_uniforms; i++) {
-        char name[MAX_ID_LEN];
-        struct ngpu_program_variable_info *info = program_variable_info_create();
-        if (!info) {
-            ngli_hmap_freep(&umap);
-            return NULL;
-        }
-
-        GLenum type;
-        GLint size;
-        gl->funcs.GetActiveUniform(pid, i, sizeof(name), NULL, &size, &type, name);
-
-        /* Remove [0] suffix from names of uniform arrays */
-        name[strcspn(name, "[")] = 0;
-        info->location = gl->funcs.GetUniformLocation(pid, name);
-
-        if (type == GL_IMAGE_2D) {
-            gl->funcs.GetUniformiv(pid, info->location, &info->binding);
-        } else {
-            info->binding = -1;
-        }
-
-        LOG(DEBUG, "uniform[%d/%d]: %s location:%d binding=%d",
-            i + 1, nb_active_uniforms, name, info->location, info->binding);
-
-        int ret = ngli_hmap_set_str(umap, name, info);
-        if (ret < 0) {
-            free_pinfo(NULL, info);
-            ngli_hmap_freep(&umap);
-            return NULL;
-        }
-    }
-
-    return umap;
-}
-
-static struct hmap *program_probe_attributes(struct glcontext *gl, GLuint pid)
-{
-    struct hmap *amap = ngli_hmap_create(NGLI_HMAP_TYPE_STR);
-    if (!amap)
-        return NULL;
-    ngli_hmap_set_free_func(amap, free_pinfo, NULL);
-
-    GLint nb_active_attributes;
-    gl->funcs.GetProgramiv(pid, GL_ACTIVE_ATTRIBUTES, &nb_active_attributes);
-    for (GLint i = 0; i < nb_active_attributes; i++) {
-        char name[MAX_ID_LEN];
-        struct ngpu_program_variable_info *info = program_variable_info_create();
-        if (!info) {
-            ngli_hmap_freep(&amap);
-            return NULL;
-        }
-
-        GLenum type;
-        GLint size;
-        gl->funcs.GetActiveAttrib(pid, i, sizeof(name), NULL, &size, &type, name);
-        info->location = gl->funcs.GetAttribLocation(pid, name);
-        LOG(DEBUG, "attribute[%d/%d]: %s location:%d",
-            i + 1, nb_active_attributes, name, info->location);
-
-        int ret = ngli_hmap_set_str(amap, name, info);
-        if (ret < 0) {
-            free_pinfo(NULL, info);
-            ngli_hmap_freep(&amap);
-            return NULL;
-        }
-    }
-
-    return amap;
-}
-
-static struct hmap *program_probe_buffer_blocks(struct glcontext *gl, GLuint pid)
-{
-    struct hmap *bmap = ngli_hmap_create(NGLI_HMAP_TYPE_STR);
-    if (!bmap)
-        return NULL;
-    ngli_hmap_set_free_func(bmap, free_pinfo, NULL);
-
-    /* Uniform Buffers */
-    GLint nb_active_uniform_buffers;
-    gl->funcs.GetProgramiv(pid, GL_ACTIVE_UNIFORM_BLOCKS, &nb_active_uniform_buffers);
-    for (GLint i = 0; i < nb_active_uniform_buffers; i++) {
-        struct ngpu_program_variable_info *info = program_variable_info_create();
-        if (!info) {
-            ngli_hmap_freep(&bmap);
-            return NULL;
-        }
-
-        char name[MAX_ID_LEN] = {0};
-        gl->funcs.GetActiveUniformBlockName(pid, i, sizeof(name), NULL, name);
-
-        const GLuint block_index = gl->funcs.GetUniformBlockIndex(pid, name);
-        gl->funcs.GetActiveUniformBlockiv(pid, block_index, GL_UNIFORM_BLOCK_BINDING, &info->binding);
-
-        GLint block_size = 0;
-        gl->funcs.GetActiveUniformBlockiv(pid, block_index, GL_UNIFORM_BLOCK_DATA_SIZE, &block_size);
-
-        LOG(DEBUG, "ubo[%d/%d]: %s binding:%d size:%d",
-            i + 1, nb_active_uniform_buffers, name, info->binding, block_size);
-
-        int ret = ngli_hmap_set_str(bmap, name, info);
-        if (ret < 0) {
-            free_pinfo(NULL, info);
-            ngli_hmap_freep(&bmap);
-            return NULL;
-        }
-    }
-
-    if (!((gl->features & NGLI_FEATURE_GL_PROGRAM_INTERFACE_QUERY) &&
-          (gl->features & NGLI_FEATURE_GL_SHADER_STORAGE_BUFFER_OBJECT)))
-        return bmap;
-
-    /* Shader Storage Buffers */
-    GLint nb_active_buffers;
-    gl->funcs.GetProgramInterfaceiv(pid, GL_SHADER_STORAGE_BLOCK,
-                                 GL_ACTIVE_RESOURCES, &nb_active_buffers);
-    for (GLint i = 0; i < nb_active_buffers; i++) {
-        char name[MAX_ID_LEN] = {0};
-        struct ngpu_program_variable_info *info = program_variable_info_create();
-        if (!info) {
-            ngli_hmap_freep(&bmap);
-            return NULL;
-        }
-
-        gl->funcs.GetProgramResourceName(pid, GL_SHADER_STORAGE_BLOCK, i, sizeof(name), NULL, name);
-        GLuint block_index = gl->funcs.GetProgramResourceIndex(pid, GL_SHADER_STORAGE_BLOCK, name);
-        static const GLenum props[] = {GL_BUFFER_BINDING};
-        gl->funcs.GetProgramResourceiv(pid, GL_SHADER_STORAGE_BLOCK, block_index,
-                                    (GLsizei)NGLI_ARRAY_NB(props), props, 1, NULL, &info->binding);
-
-        LOG(DEBUG, "ssbo[%d/%d]: %s binding:%d",
-            i + 1, nb_active_buffers, name, info->binding);
-
-        int ret = ngli_hmap_set_str(bmap, name, info);
-        if (ret < 0) {
-            free_pinfo(NULL, info);
-            ngli_hmap_freep(&bmap);
-            return NULL;
-        }
-    }
-
-    return bmap;
-}
-
 struct ngpu_program *ngpu_program_gl_create(struct ngpu_ctx *gpu_ctx)
 {
     struct ngpu_program_gl *s = ngli_calloc(1, sizeof(*s));
@@ -324,14 +156,6 @@ int ngpu_program_gl_init(struct ngpu_program *s, const struct ngpu_program_param
     for (size_t i = 0; i < NGLI_ARRAY_NB(shaders); i++)
         gl->funcs.DeleteShader(shaders[i].id);
 
-    s->uniforms = program_probe_uniforms(gl, s_priv->id);
-    s->attributes = program_probe_attributes(gl, s_priv->id);
-    s->buffer_blocks = program_probe_buffer_blocks(gl, s_priv->id);
-    if (!s->uniforms || !s->attributes || !s->buffer_blocks) {
-        ret = NGL_ERROR_MEMORY;
-        goto fail;
-    }
-
     return 0;
 
 fail:
@@ -347,9 +171,6 @@ void ngpu_program_gl_freep(struct ngpu_program **sp)
         return;
     struct ngpu_program *s = *sp;
     struct ngpu_program_gl *s_priv = (struct ngpu_program_gl *)s;
-    ngli_hmap_freep(&s->uniforms);
-    ngli_hmap_freep(&s->attributes);
-    ngli_hmap_freep(&s->buffer_blocks);
     struct ngpu_ctx_gl *gpu_ctx_gl = (struct ngpu_ctx_gl *)s->gpu_ctx;
     struct glcontext *gl = gpu_ctx_gl->glcontext;
     gl->funcs.DeleteProgram(s_priv->id);

--- a/libnopegl/src/ngpu/program.h
+++ b/libnopegl/src/ngpu/program.h
@@ -23,16 +23,9 @@
 #ifndef NGPU_PROGRAM_H
 #define NGPU_PROGRAM_H
 
-#include "utils/hmap.h"
-
 struct ngpu_ctx;
 
 #define MAX_ID_LEN 128
-
-struct ngpu_program_variable_info {
-    int binding;
-    int location;
-};
 
 enum ngpu_program_stage {
     NGPU_PROGRAM_STAGE_VERT,
@@ -57,9 +50,6 @@ struct ngpu_program_params {
 
 struct ngpu_program {
     struct ngpu_ctx *gpu_ctx;
-    struct hmap *uniforms;
-    struct hmap *attributes;
-    struct hmap *buffer_blocks;
 };
 
 struct ngpu_program *ngpu_program_create(struct ngpu_ctx *gpu_ctx);

--- a/libnopegl/src/pipeline_compat.c
+++ b/libnopegl/src/pipeline_compat.c
@@ -281,7 +281,7 @@ int ngli_pipeline_compat_update_uniform_count(struct pipeline_compat *s, int32_t
     if (index == -1)
         return NGL_ERROR_NOT_FOUND;
 
-    const int32_t stage = index >> 16;
+    const enum ngpu_program_stage stage = (enum ngpu_program_stage)(index >> 16);
     const int32_t field_index = index & 0xffff;
     const struct ngpu_block_desc *block = &s->compat_info->ublocks[stage];
     const struct ngpu_block_field *fields = ngli_darray_data(&block->fields);


### PR DESCRIPTION
```
Shader probing is used exclusively in program_gl_utils to set the locations and
bindings of the program for older versions of OpenGL that do not support
explicit locations and bindings. Additionally, probing the attribute locations
is solely used for determining whether the shader requires re-linking, a
process that can be inlined directly into program_gl_utils.
```

Simplifies the maintenance of the GL backend !