### PR TITLE
build: bump nope.media version to 13.1.0

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -183,10 +183,10 @@ _EXTERNAL_DEPS = dict(
         sha256="a5b24188a1a7c3d4a7a1295bd597f35ad5ef7757796e6a8db1cc1b922ff84e16",
     ),
     nopemd=dict(
-        version="13.0.0",
+        version="13.1.0",
         url="https://github.com/NopeForge/nope.media/archive/v@VERSION@.tar.gz",
         dst_file="nope.media-@VERSION@.tar.gz",
-        sha256="5cb5f9cac328b65d30fdec1f5fd5159b402b0a19e69b2b27fe34dd4fe88e730b",
+        sha256="fb8dd91282f1a60ea1375edfbb5879783a2df1a9a33c2165f59f5ea5b4e0aa27",
     ),
     egl_registry=dict(
         version="9ab6036",


### PR DESCRIPTION
Fixes build with FFmpeg 8.0.